### PR TITLE
Changes due to heidelpay GmbH re-branding

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,7 +3,7 @@ Lizenzvereinbarung Plug-in
 
 I. Präambel
 
-Diese Lizenzvereinbarung Plug-in (nachfolgend – „Vereinbarung“) bildet einen Vertrag zwischen dem Nutzer des Plug-ins und der Heidelberger Payment GmbH (nachfolgend „heidelpay“).
+Diese Lizenzvereinbarung Plug-in (nachfolgend – „Vereinbarung“) bildet einen Vertrag zwischen dem Nutzer des Plug-ins und der heidelpay GmbH (nachfolgend „heidelpay“).
 
 Das Plug-in von heidelpay ist ein Software-Programm, welches die Schnittstelle zum Payment-System von heidelpay mit einer Anwendung (zum Beispiel: Shopsystem, Warenwirtschaft, Debitorenmanagement etc.) verbindet. Das Plug-in dient dem Datenaustausch zwischen dem Payment-System von heidelpay und der Anwendung. Das Plug-in erweitert den Funktionsumfang der Anwendung hinsichtlich der mit heidelpay gesondert vertraglich vereinbarten Leistungen. 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PHP 7.1](https://img.shields.io/badge/php-7.1-blue.svg)](http://www.php.net)
 [![PHP 7.2](https://img.shields.io/badge/php-7.2-blue.svg)](http://www.php.net)
 
-![Logo](https://dev.heidelpay.de/devHeidelpay_400_180.jpg)
+![Logo](http://dev.heidelpay.com/devHeidelpay_400_180.jpg)
 
 **heidelpay message code mapper**
 

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,13 @@
     "authors": [
         {
             "name": "Stephano Vogel",
-            "email": "development@heidelpay.de"
+            "email": "development@heidelpay.com"
         }
     ],
     "support" : {
         "email" : "development@heidelpay.de"
     },
-    "homepage" : "https://dev.heidelpay.de",
+    "homepage" : "http://dev.heidelpay.com",
     "autoload" : {
         "psr-4": {
             "Heidelpay\\MessageCodeMapper\\": "lib"

--- a/lib/Exceptions/MissingLocaleFileException.php
+++ b/lib/Exceptions/MissingLocaleFileException.php
@@ -8,15 +8,13 @@ use Exception;
  * This class is used for indicating a missing locale file for the library usage.
  *
  * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ * @copyright Copyright © 2016-present heidelpay GmbH. All rights reserved.
  *
- * @link https://dev.heidelpay.de/php-messages-code-mapper
+ * @link http://dev.heidelpay.com/php-messages-code-mapper
  *
- * @author Stephano Vogel
+ * @author Stephano Vogel <development@heidelpay.com>
  *
- * @package heidelpay
- * @subpackage php-messages-code-mapper
- * @category php-messages-code-mapper
+ * @package heidelpay\php-message-code-mapper\exceptions
  */
 class MissingLocaleFileException extends Exception
 {

--- a/lib/Helpers/FileSystem.php
+++ b/lib/Helpers/FileSystem.php
@@ -6,15 +6,13 @@ namespace Heidelpay\MessageCodeMapper\Helpers;
  * This class provides the functionality for reading the locale files.
  *
  * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ * @copyright Copyright © 2016-present heidelpay GmbH. All rights reserved.
  *
- * @link https://dev.heidelpay.de/php-messages-code-mapper
+ * @link http://dev.heidelpay.com/php-messages-code-mapper
  *
- * @author Stephano Vogel
+ * @author Stephano Vogel <development@heidelpay.com>
  *
- * @package heidelpay
- * @subpackage php-messages-code-mapper
- * @category php-messages-code-mapper
+ * @package heidelpay\php-message-code-mapper
  */
 class FileSystem
 {

--- a/lib/MessageCodeMapper.php
+++ b/lib/MessageCodeMapper.php
@@ -13,15 +13,13 @@ use Heidelpay\MessageCodeMapper\Helpers\FileSystem;
  * The path is important when own implementations have to be used.
  *
  * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ * @copyright Copyright © 2016-present heidelpay GmbH. All rights reserved.
  *
- * @link https://dev.heidelpay.de/php-messages-code-mapper
+ * @link http://dev.heidelpay.com/php-messages-code-mapper
  *
- * @author Stephano Vogel
+ * @author Stephano Vogel <development@heidelpay.com>
  *
- * @package heidelpay
- * @subpackage php-messages-code-mapper
- * @category php-messages-code-mapper
+ * @package heidelpay\php-message-code-mapper
  */
 class MessageCodeMapper
 {

--- a/tests/unit/MessageCodeMapperTest.php
+++ b/tests/unit/MessageCodeMapperTest.php
@@ -10,11 +10,11 @@ use PHPUnit\Framework\TestCase;
  * This class provides unit tests for the CustomerMessage implementation.
  *
  * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ * @copyright Copyright © 2016-present heidelpay GmbH. All rights reserved.
  *
- * @link https://dev.heidelpay.de/php-messages-code-mapper
+ * @link http://dev.heidelpay.com/php-messages-code-mapper
  *
- * @author Stephano Vogel
+ * @author Stephano Vogel <development@heidelpay.com>
  *
  * @package heidelpay
  * @subpackage php-messages-code-mapper


### PR DESCRIPTION
- Changed "Heidelberger Payment GmbH" to "heidelpay GmbH"
- Changed "dev.heidelpay.de" to "dev.heidelpay.com" in some cases