### PR TITLE
Update to allow v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^5.6.0|^7.0.0"
+        "php": "^5.6.0|^7.0.0|^8.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7",


### PR DESCRIPTION
We would like to have our CI check PHP8 compatibility
But without this lib allowing it we are currently blocked

You could also consider removing v6 as even 7.3 is already EOL
I recommend 7.4+ or at least 7.3+ if very conservative

Also CI using GithubActions should be enabled to verify both min/max versions.
See e.g. https://github.com/spryker/decimal-object/blob/master/.github/workflows/ci.yml#L16
Last run was apparently 3 years ago